### PR TITLE
Refactor CI & deprecate dedicated :potoken build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,18 +12,44 @@ on:
   workflow_dispatch:
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --no-cache --tag canofsocks/holo-downloader:latest
-    - name: Push the Docker Image
-      run: docker login -u canofsocks -p ${{ secrets.DOCKER_TOKEN }} && docker push canofsocks/holo-downloader:latest
-    - name: Build the Potoken image
-      run: docker build . --file DockerfilePotoken --no-cache --tag canofsocks/holo-downloader:potoken
-    - name: Push the Potoken Image
-      run: docker login -u canofsocks -p ${{ secrets.DOCKER_TOKEN }} && docker push canofsocks/holo-downloader:potoken
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          
+      - name: Log into GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Docker create tag meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            canofsocks/holo-downloader
+            ghcr.io/canofsocks/holo-downloader
+          tags: |
+            type=edge,branch=main
+            type=raw,value=potoken
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            
+      - name: Build and publish
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/DockerfilePotoken
+++ b/DockerfilePotoken
@@ -1,2 +1,0 @@
-FROM canofsocks/holo-downloader:latest
-RUN pip install --no-cache-dir -U bgutil-ytdlp-pot-provider

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ chat-downloader>=0.2.8
 psutil>=5.9.4
 py3createtorrent>=1.2.0
 croniter>=3.0.3
+bgutil-ytdlp-pot-provider>=1.2.2


### PR DESCRIPTION
POToken is increasingly mandatory to access high quality formats using yt-dlp. The potoken plugin is now included in the base image by default.

CI was refactored to publish to both GHCR and Docker Hub, in lieu of Docker Hub's increasingly restrictive API limitations. 
Additionally, new builds will be tagged with more descriptive tags (dates, commit-hashes, branch names if applicable).

It will also ensure new builds continue to be published to :latest and :potoken to ensure ongoing updates for existing users.