### PR TITLE
fix(ci): add publishing `latest` tag for docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,6 +42,7 @@ jobs:
           tags: |
             type=edge,branch=main
             type=raw,value=potoken
+            type=raw,value=latest
             type=schedule
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
Forgot to also publish to `latest` for existing users (nnoi)