### PR TITLE
Ignore cookies for grabbing upcoming/live videos

### DIFF
--- a/common.py
+++ b/common.py
@@ -207,7 +207,7 @@ def get_upcoming_or_live_videos(channel_id: str, config: ConfigHandler = None, t
         'sleep_interval': 1,
         'sleep_interval_requests': 1,
         'no_warnings': True,
-        'cookiefile': config.get_cookies_file(),
+        #'cookiefile': config.get_cookies_file(),
         "logger": YTDLPLogger(logger=this_logger),
     }
     if config.get_ytlp_playlist_limit():


### PR DESCRIPTION
This fixes an issue where running holo-downloader with cookies may result in being unable to grab the live status of upcoming/live streams from playlists because YouTube is stupid.